### PR TITLE
Improve sharing via apps with custom URI schemes

### DIFF
--- a/src/sharers/messenger.js
+++ b/src/sharers/messenger.js
@@ -12,5 +12,5 @@ export default function messenger(options = {}) {
     link: url,
   });
 
-  window.location.assign(`fb-messenger://share?${params}`);
+  return window.location.assign(`fb-messenger://share?${params}`);
 }

--- a/src/sharers/messenger.js
+++ b/src/sharers/messenger.js
@@ -12,5 +12,5 @@ export default function messenger(options = {}) {
     link: url,
   });
 
-  return window.open(`fb-messenger://share?${params}`);
+  window.location.assign(`fb-messenger://share?${params}`);
 }

--- a/src/sharers/tests/messenger.test.js
+++ b/src/sharers/tests/messenger.test.js
@@ -4,11 +4,11 @@ import messenger from '../messenger';
 
 describe('messenger', () => {
   beforeEach(() => {
-    window.open = jest.fn();
+    window.location.assign = jest.fn();
   });
 
   afterEach(() => {
-    window.open.mockReset();
+    window.location.assign.mockReset();
   });
 
   it('should throw without fbAppId', () => {
@@ -20,7 +20,7 @@ describe('messenger', () => {
 
     messenger({ fbAppId: fixture });
 
-    expect(window.open.mock.calls[0][0]).toBe(`fb-messenger://share?app_id=${fixture}`);
+    expect(window.location.assign.mock.calls[0][0]).toBe(`fb-messenger://share?app_id=${fixture}`);
   });
 
   it('should call with url and fbAppId', () => {
@@ -28,6 +28,6 @@ describe('messenger', () => {
 
     messenger({ url: fixture, fbAppId: 123 });
 
-    expect(window.open.mock.calls[0][0]).toBe(`fb-messenger://share?app_id=123&link=${encodeURIComponent(fixture)}`);
+    expect(window.location.assign.mock.calls[0][0]).toBe(`fb-messenger://share?app_id=123&link=${encodeURIComponent(fixture)}`);
   });
 });

--- a/src/sharers/tests/viber.test.js
+++ b/src/sharers/tests/viber.test.js
@@ -4,11 +4,11 @@ import viber from '../viber';
 
 describe('viber', () => {
   beforeEach(() => {
-    window.open = jest.fn();
+    window.location.assign = jest.fn();
   });
 
   afterEach(() => {
-    window.open.mockReset();
+    window.location.assign.mockReset();
   });
 
   it('should throw if title and url are empty', () => {
@@ -20,7 +20,7 @@ describe('viber', () => {
 
     viber({ url: fixture });
 
-    expect(window.open.mock.calls[0][0]).toBe(`viber://forward?text=${encodeURIComponent(fixture)}`);
+    expect(window.location.assign.mock.calls[0][0]).toBe(`viber://forward?text=${encodeURIComponent(fixture)}`);
   });
 
   it('should call with title', () => {
@@ -28,7 +28,7 @@ describe('viber', () => {
 
     viber({ title: fixture });
 
-    expect(window.open.mock.calls[0][0]).toBe(`viber://forward?text=${encodeURIComponent(fixture)}`);
+    expect(window.location.assign.mock.calls[0][0]).toBe(`viber://forward?text=${encodeURIComponent(fixture)}`);
   });
 
   it('should call with title and url', () => {
@@ -37,6 +37,6 @@ describe('viber', () => {
 
     viber({ title, url });
 
-    expect(window.open.mock.calls[0][0]).toBe(`viber://forward?text=${encodeURIComponent(`${title} ${url}`)}`);
+    expect(window.location.assign.mock.calls[0][0]).toBe(`viber://forward?text=${encodeURIComponent(`${title} ${url}`)}`);
   });
 });

--- a/src/sharers/tests/whatsapp.test.js
+++ b/src/sharers/tests/whatsapp.test.js
@@ -4,17 +4,17 @@ import whatsapp from '../whatsapp';
 
 describe('whatsapp', () => {
   beforeEach(() => {
-    window.open = jest.fn();
+    window.location.assign = jest.fn();
   });
 
   afterEach(() => {
-    window.open.mockReset();
+    window.location.assign.mockReset();
   });
 
   it('should call without params', () => {
     whatsapp();
 
-    expect(window.open.mock.calls[0][0]).toBe('whatsapp://send?text=');
+    expect(window.location.assign.mock.calls[0][0]).toBe('whatsapp://send?text=');
   });
 
   it('should call with url', () => {
@@ -22,7 +22,7 @@ describe('whatsapp', () => {
 
     whatsapp({ url: fixture });
 
-    expect(window.open.mock.calls[0][0]).toBe(`whatsapp://send?text=${encodeURIComponent(fixture)}`);
+    expect(window.location.assign.mock.calls[0][0]).toBe(`whatsapp://send?text=${encodeURIComponent(fixture)}`);
   });
 
   it('should call with title', () => {
@@ -30,7 +30,7 @@ describe('whatsapp', () => {
 
     whatsapp({ title: fixture });
 
-    expect(window.open.mock.calls[0][0]).toBe(`whatsapp://send?text=${encodeURIComponent(fixture)}`);
+    expect(window.location.assign.mock.calls[0][0]).toBe(`whatsapp://send?text=${encodeURIComponent(fixture)}`);
   });
 
   it('should call with title and url', () => {
@@ -39,6 +39,6 @@ describe('whatsapp', () => {
 
     whatsapp({ title, url });
 
-    expect(window.open.mock.calls[0][0]).toBe(`whatsapp://send?text=${encodeURIComponent(`${title} ${url}`)}`);
+    expect(window.location.assign.mock.calls[0][0]).toBe(`whatsapp://send?text=${encodeURIComponent(`${title} ${url}`)}`);
   });
 });

--- a/src/sharers/viber.js
+++ b/src/sharers/viber.js
@@ -10,5 +10,5 @@ export default function viber(options = {}) {
     text: [title, url].filter(item => item).join(' '),
   });
 
-  window.location.assign(`viber://forward?${params}`);
+  return window.location.assign(`viber://forward?${params}`);
 }

--- a/src/sharers/viber.js
+++ b/src/sharers/viber.js
@@ -1,4 +1,3 @@
-import { WIN_PARAMS } from 'config';
 import encodeParams from 'utils/encodeParams';
 
 export default function viber(options = {}) {
@@ -11,5 +10,5 @@ export default function viber(options = {}) {
     text: [title, url].filter(item => item).join(' '),
   });
 
-  return window.open(`viber://forward?${params}`, '_blank', WIN_PARAMS);
+  window.location.assign(`viber://forward?${params}`);
 }

--- a/src/sharers/whatsapp.js
+++ b/src/sharers/whatsapp.js
@@ -7,5 +7,5 @@ export default function whatsapp(options = {}) {
     text: [title, url].filter(item => item).join(' '),
   });
 
-  window.location.assign(`whatsapp://send?${params}`);
+  return window.location.assign(`whatsapp://send?${params}`);
 }

--- a/src/sharers/whatsapp.js
+++ b/src/sharers/whatsapp.js
@@ -1,4 +1,3 @@
-import { WIN_PARAMS } from 'config';
 import encodeParams from 'utils/encodeParams';
 
 export default function whatsapp(options = {}) {
@@ -8,6 +7,5 @@ export default function whatsapp(options = {}) {
     text: [title, url].filter(item => item).join(' '),
   });
 
-  // TODO: check for mobile ?
-  return window.open(`whatsapp://send?${params}`, '_blank', WIN_PARAMS);
+  window.location.assign(`whatsapp://send?${params}`);
 }


### PR DESCRIPTION
Use `window.location.assign` instead of `window.open`.

Urls like 'whatsapp://` will be handled only If the corresponding app is installed.