### PR TITLE
Fix email body not displaying in Outlook 2010

### DIFF
--- a/src/sharers/email.js
+++ b/src/sharers/email.js
@@ -4,6 +4,6 @@ export default function email(options = {}) {
   } = options;
 
   const body = `${title || ''}\r\n${description || ''}\r\n${url || ''}`;
-  const uri = `mailto:?subject=&body=${encodeURIComponent(body)}`;
+  const uri = `mailto:?body=${encodeURIComponent(body)}`;
   return window.location.assign(uri);
 }

--- a/src/sharers/tests/email.test.js
+++ b/src/sharers/tests/email.test.js
@@ -10,13 +10,13 @@ describe('email', () => {
 
   it('should call without params', () => {
     email();
-    expect(window.location.assign).toBeCalledWith('mailto:?subject=&body=%0D%0A%0D%0A');
+    expect(window.location.assign).toBeCalledWith('mailto:?body=%0D%0A%0D%0A');
   });
 
   it('should call with url', () => {
     const fixture = faker.internet.url();
     email({ url: fixture });
-    expect(window.location.assign).toBeCalledWith(`mailto:?subject=&body=%0D%0A%0D%0A${encodeURIComponent(fixture)}`);
+    expect(window.location.assign).toBeCalledWith(`mailto:?&body=%0D%0A%0D%0A${encodeURIComponent(fixture)}`);
   });
 
   it('should call with title', () => {
@@ -24,7 +24,7 @@ describe('email', () => {
 
     email({ title: fixture });
 
-    expect(window.location.assign).toBeCalledWith(`mailto:?subject=&body=${encodeURIComponent(fixture)}%0D%0A%0D%0A`);
+    expect(window.location.assign).toBeCalledWith(`mailto:?body=${encodeURIComponent(fixture)}%0D%0A%0D%0A`);
   });
 
   it('should call with description', () => {
@@ -32,6 +32,6 @@ describe('email', () => {
 
     email({ description: fixture });
 
-    expect(window.location.assign).toBeCalledWith(`mailto:?subject=&body=%0D%0A${encodeURIComponent(fixture)}%0D%0A`);
+    expect(window.location.assign).toBeCalledWith(`mailto:?body=%0D%0A${encodeURIComponent(fixture)}%0D%0A`);
   });
 });

--- a/src/sharers/tests/email.test.js
+++ b/src/sharers/tests/email.test.js
@@ -16,7 +16,7 @@ describe('email', () => {
   it('should call with url', () => {
     const fixture = faker.internet.url();
     email({ url: fixture });
-    expect(window.location.assign).toBeCalledWith(`mailto:?&body=%0D%0A%0D%0A${encodeURIComponent(fixture)}`);
+    expect(window.location.assign).toBeCalledWith(`mailto:?body=%0D%0A%0D%0A${encodeURIComponent(fixture)}`);
   });
 
   it('should call with title', () => {


### PR DESCRIPTION
I've removed the empty subject parameter from the email sharer which was causing the subject of the created email to be "&body=" in some email clients (Outlook 2010) and for the actual body not to be displayed.

I've tested in a number of other email clients to ensure that this doesn't cause any unwanted side effects but I'm not sure if this was deliberate and I'm missing something 🙃 

What do you think?
