### PR TITLE
Add missing quote parameter regarding FbShare doc

### DIFF
--- a/src/sharers/fbShare.js
+++ b/src/sharers/fbShare.js
@@ -3,7 +3,7 @@ import encodeParams from '../utils/encodeParams';
 
 export function getFbShareUrl(options = {}) {
   const {
-    fbAppId, url, hashtag, redirectUri,
+    fbAppId, url, hashtag, redirectUri, quote,
   } = options;
 
   if (!fbAppId) {
@@ -16,6 +16,7 @@ export function getFbShareUrl(options = {}) {
     redirect_uri: redirectUri,
     href: url,
     hashtag,
+    quote,
   });
 
   return `https://www.facebook.com/dialog/share?${params}`;


### PR DESCRIPTION
It miss the parameter quote regarding the FbShareDialog : https://developers.facebook.com/docs/sharing/reference/share-dialog