### PR TITLE
export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "main": "./dist/vanilla-sharing.umd.js",
   "module": "./dist/vanilla-sharing.esm.js",
   "exports": {
-    ".": "./dist/vanilla-sharing.umd.js"
+    ".": "./dist/vanilla-sharing.umd.js",
+    "./package.json": "./package.json"
   },
   "types": "vanilla-sharing.d.ts",
   "scripts": {


### PR DESCRIPTION
Fixes an error with rollup-plugin-svelte

See https://github.com/niieani/hashids.js/pull/330 for a similar fix for another library.